### PR TITLE
Enforce username when using JWT

### DIFF
--- a/client/src/ecs/plugins/html2d/html/Label.svelte
+++ b/client/src/ecs/plugins/html2d/html/Label.svelte
@@ -5,6 +5,7 @@
   import { Html2d } from "../components";
   import { Relm } from "~/stores/Relm";
   import { mode } from "~/stores/mode";
+  import { Identity } from "~/identity/Identity";
   import { DRAG_DISTANCE_THRESHOLD } from "~/config/constants";
 
   export let content;
@@ -36,9 +37,7 @@
     if ($Relm.avatar === entity) {
       // TODO: make a way for Avatar to subscribe to ECS component
       // changes instead of this hack:
-      $Relm.identities.me.sharedFields.update(($fields) => {
-        return { ...$fields, name: text };
-      });
+      $Relm.identities.me.setName(text);
     } else {
       // Broadcast changes
       $Relm.wdoc.syncFrom(entity);

--- a/client/src/identity/Identity.ts
+++ b/client/src/identity/Identity.ts
@@ -9,20 +9,17 @@ import {
   PlayerID,
 } from "./types";
 
-import { Relm } from "~/stores/Relm";
-import { get } from "svelte/store";
-
 /**
  * A participant's Identity is created from Shared fields such as
  * name and color, as well as Local fields, such as a temporary clientId.
- * 
+ *
  * There are two types of identities: local & remote. A `local` identity
  * is assembled from 2 "layers", with each subsequent layer taking higher
  * precedence:
- * 
+ *
  * 1. defaultIdentity - this provides a random name and color
  * 2. localstorageSharedFields - provides name and color, stored in localstorage
- * 
+ *
  * A `remote` identity is created based on SharedIdentityFields that are sent
  * via yjs.
  */
@@ -102,11 +99,8 @@ export class Identity implements Readable<IdentityData> {
   subscribe(handler) {
     return this.derivedIdentity.subscribe(handler);
   }
-  
-  setName(username) {
-    const $Relm = get(Relm);
-    $Relm.identities.me.sharedFields.update(($fields) => {
-      return { ...$fields, name: username };
-    });
+
+  setName(name) {
+    this.sharedFields.update(($fields) => ({ ...$fields, name }));
   }
 }

--- a/client/src/identity/Identity.ts
+++ b/client/src/identity/Identity.ts
@@ -9,6 +9,9 @@ import {
   PlayerID,
 } from "./types";
 
+import { Relm } from "~/stores/Relm";
+import { get } from "svelte/store";
+
 /**
  * A participant's Identity is created from Shared fields such as
  * name and color, as well as Local fields, such as a temporary clientId.
@@ -98,5 +101,12 @@ export class Identity implements Readable<IdentityData> {
 
   subscribe(handler) {
     return this.derivedIdentity.subscribe(handler);
+  }
+  
+  setName(username) {
+    const $Relm = get(Relm);
+    $Relm.identities.me.sharedFields.update(($fields) => {
+      return { ...$fields, name: username };
+    });
   }
 }

--- a/client/src/stores/connection.ts
+++ b/client/src/stores/connection.ts
@@ -37,8 +37,8 @@ export type ConnectError = {
 };
 export type ConnectStatus = ConnectInitial | ConnectOptions | ConnectError;
 
-async function playerPermit(params, serverUrl, room) {
-  let url = `${serverUrl}/relm/${room}/can/access`;
+async function playerPermit(params, serverUrl, subrelm) {
+  let url = `${serverUrl}/relm/${subrelm}/can/access`;
   if (params.t) {
     url += `?t=${params.t}`;
   }
@@ -52,13 +52,13 @@ async function playerPermit(params, serverUrl, room) {
     },
   });
   if (res.data.status === "success") {
-    if (res.data.relm.authmode == "public") {
+    if (res.data.authmode == "public") {
       console.log("public authmode enabled");
     } else {
       console.log("jwt authmode enabled");
-      console.log("username from JWT", res.data.relm.username);
+      console.log("username from JWT", res.data.user?.name);
     }
-    return res.data.relm;
+    return res.data;
   } else {
     console.error(`Unable to get permission`, res);
     throw Error(`Unable to get permission`);
@@ -71,12 +71,12 @@ export const connection: Readable<ConnectStatus> = derived(
     getSecureParams(window.location.href)
       .then((params) => {
         playerPermit(params, config.serverUrl, $subrelm)
-          .then((relm) => {
+          .then(({ relm, user }) => {
             set({
               state: "connected",
               url: config.serverYjsUrl,
               room: relm.permanentDocId,
-              username: relm.username,
+              username: user?.name,
               params,
             });
           })

--- a/client/src/world/WorldManager.ts
+++ b/client/src/world/WorldManager.ts
@@ -149,7 +149,7 @@ export default class WorldManager {
 
     // set name from server, if available (overrides localstorage)
     if (connectOpts.username) {
-      // this.identities.me.setName(connectOpts.username)
+      this.identities.me.setName(connectOpts.username)
     }
 
     // Init loading

--- a/server/src/relm_router.js
+++ b/server/src/relm_router.js
@@ -211,31 +211,38 @@ relmRouter.get(
     await auth(req, res, (err) => {
       if (!err) {
         if (config.JWTSECRET === undefined) {
-          req.relm.authmode='public'
           util.respond(res, 200, {
-            status: 'success',
-            action: 'permit',
+            status: "success",
+            action: "permit",
+            authmode: "public",
             relm: req.relm,
-          })
+          });
         } else {
-          const jwtresult=JWT_is_valid(req.headers[`x-relm-jwt`],config.JWTSECRET.toString())
-          if ((jwtresult.isValid) && (req.relmName == jwtresult.decoded.allowedrelm)) {  // if jwt check that the jwt token payload matches the relmName
-            req.relm.authmode='jwt'
-            req.relm.username=jwtresult.decoded.username
+          const jwtresult = JWT_is_valid(
+            req.headers[`x-relm-jwt`],
+            config.JWTSECRET.toString()
+          );
+          if (
+            jwtresult.isValid &&
+            req.relmName === jwtresult.decoded.allowedrelm
+          ) {
+            // if jwt check that the jwt token payload matches the relmName
             util.respond(res, 200, {
-              status: 'success',
-              action: 'permit',
+              status: "success",
+              action: "permit",
+              authmode: "jwt",
               relm: req.relm,
-            })
+              user: { name: jwtresult.decoded.username },
+            });
           } else {
-            throw createError(401, 'access denied')
+            throw createError(401, "access denied");
           }
         }
       } else {
-        console.warn('permission err', err)
-        throw err
+        console.warn("permission err", err);
+        throw err;
       }
-    })
+    });
   })
 )
 


### PR DESCRIPTION
Fix issue with JWT not being able to set username, and keep data passed from server to client in 'relm' and 'user' objects.