### PR TITLE
Fix for some players landing at the wrong spot: Longer wait for default entryway data

### DIFF
--- a/client/src/main/Program.ts
+++ b/client/src/main/Program.ts
@@ -514,11 +514,15 @@ export function makeProgram(): Program {
           Cmd.batch([
             getPositionFromEntryway(state.worldDoc, state.pageParams.entryway),
             (dispatch) => {
-              // If we can't find the entryway in 1.5 sec, assume there is
-              // no entryway data to be found, and use 0,0,0 as entryway
+              // If we can't find the entryway in 30 sec, assume there is
+              // no entryway data to be found, and use 0,0,0 as entryway.
+              // This was initially 1.5 sec, but low bandwidth connections
+              // require more time for the entryway data in YJS to arrive.
+              // This longer timeout directly affects the loading time of new worlds.
+              const WAIT_FOR_YJS_DEFAULT_ENTRYWAY = 30_000;
               setTimeout(() => {
                 dispatch({ id: "assumeOriginAsEntryway" });
-              }, 1500);
+              }, WAIT_FOR_YJS_DEFAULT_ENTRYWAY);
             },
           ]),
         ];


### PR DESCRIPTION
The Relm client waits for default entryway data for 1.5 sec.  This PR ups that to 30 sec.

The bug:
On a customer world, some players were experiencing their starting position being off in space, instead of at the designated entryway.

Repro: 
I used the browser inspector to throttle bandwidth to 3G/4G levels.  My impression is that, on low bandwidth connections, assets are undergoing loading, which may be slowing down the transfer of YJS data that contains the default entryway.

Downside: 
On worlds that don't have a default entryway set, such as newly created worlds, the Relm client has to wait for 30 sec, because it doesn't know entryway data will never come.

Imagined alternative fixes:
- Include entryway (or lack thereof) as part of early world data (before YJS /assets load).
- Prioritize YJS data over assets, or delay loading of assets until after enterway is loaded.
- Skip entryway wait for new worlds by detecting whether it's a new world at runtime.